### PR TITLE
Make CI use new org wide CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Common CI
 
 on:
   pull_request_target:
@@ -9,201 +9,16 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
-  
+
 jobs:
-  Verifying:  
-    runs-on: ubuntu-latest
-    steps:
-      - name: Start verification
-        run: echo Verification Start
-      
-      # Run assignment action 
-      - name: Assign reviewers and assignees
-        uses: dm-vdo/vdo-auto-assign@main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Remove all known labels
-        uses: buildsville/add-remove-label@v2.0.0
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          labels: verification needed, untested, public testing running, public testing done, public testing failed, private testing running, private testing done, private testing failed
-          type: remove
-
-      - name: Check for org membership
-        id: is_organization_member
-        uses: jamessingleton/is-organization-member@1.0.0
-        with:
-          organization: dm-vdo
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}              
-          
-      - name: Add untested label
-        if: ${{ steps.is_organization_member.outputs.result == 'true' }}
-        uses: buildsville/add-remove-label@v2.0.0
-        with:
-          token: ${{secrets.VDODEVEL}}
-          label: untested
-          type: add     
-          
-      - name: Add verification needed
-        if: ${{ steps.is_organization_member.outputs.result == 'false' }}
-        uses: buildsville/add-remove-label@v2.0.0
-        with:
-          token: ${{secrets.VDODEVEL}}
-          label: verification needed
-          type: add 
-              
-      - name: Wait for verification
-        if: ${{ steps.is_organization_member.outputs.result == 'false' }}      
-        uses: trstringer/manual-approval@v1
-        timeout-minutes: 1440
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: ${{ join(github.event.pull_request.requested_reviewers.*.login, ', ') }}
-          minimum-approvals: 1
-          issue-title: "Verifying pull request for testing"
-          issue-body: "Please approve or deny the testing of this pull request."
-          exclude-workflow-initiator-as-approver: false 
-          
-      - name: Remove verification needed label
-        if: ${{ steps.is_organization_member.outputs.result == 'false' }}
-        uses: buildsville/add-remove-label@v2.0.0
-        with:
-          token: ${{secrets.VDODEVEL}}
-          label: verification needed
-          type: remove       
-          
-  Public-Testing:
-    runs-on: [self-hosted, untrusted]
-    needs: [Verifying]      
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Start testing
-      run: echo Testing Start
-
-    - name: Add testing running label
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: public testing running
-        type: add
-
-    - name: Remove untested label
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: untested
-        type: remove
-        
-    - name: Run-Untrusted-Tests
-      run: |
-        sed -i 's/FEDORA37 FEDORA38 RHEL9/FEDORA36 FEDORA37/' src/perl/vdotest/vdotests.suites
-        make jenkins
-    
-    - name: Remove public testing running label
-      if: always()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: public testing running
-        type: remove
-
-    - name: Add public testing failed
-      if: failure()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: public testing failed
-        type: add
-        
-    - name: Upload artifact
-      if: failure()
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      with:
-        files: logs/**/*.xml
-    
-    - name: Prepare Logfiles
-      if: failure()
-      run: |  
-        cd logs/vdotests
-        for file in *::*.log;
-        do
-          mv ${file} ${file/::/--}
-        done
-
-    - name: Upload artifact
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Upload Test Logs
-        path: logs/vdotests/*.log
-        retention-days: 5
-
-    - name: Add public testing success
-      if: success()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: public testing done
-        type: add
-
-  Private-Testing:
-    runs-on: [self-hosted, trusted]
-    needs: [Verifying, Public-Testing]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Start Private testing
-      run: echo Private Testing Start
-      
-    - name: Add public testing success
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: public testing done
-        type: remove
-
-    - name: Add testing running label
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: private testing running
-        type: add
-        
-    - name: Run-trusted-Tests
-      run: make jenkins
-      
-    - name: Copy log file to /home/bunsen-home/artifacts
-      if: failure()
-      run: |
-        REPO=${{ github.repository }}
-        REPO=${REPO//\//-}
-        cp -a logs /home/bunsen-home/artifacts/logs.`date +'%Y%m%d%H%M'`.$REPO.${{ github.event.number }}
-    
-    - name: Remove private testing running label
-      if: always()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: private testing running
-        type: remove
-
-    - name: Add private testing failed
-      if: failure()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.GITHUB_TOKEN}}
-        label: private testing failed
-        type: add
-        
-    - name: Add private testing success
-      if: success()
-      uses: buildsville/add-remove-label@v2.0.0
-      with:
-        token: ${{secrets.VDODEVEL}}
-        label: private testing done
-        type: add
+  Run-Common-CI:
+    uses: dm-vdo/vdo-org-actions/.github/workflows/ci.yml@main
+    with:
+      # Turn this off temporarily
+      run-public-tests: false
+      public-tests-action: echo 'You need to specify commands to run here'
+      public-tests-failure-action: echo "You need to specify cleanup commands to run, i.e collecting logs"
+      # Call the Jenkins job
+      run-private-tests: true
+      private-tests-action: |
+        /permabit/ops/scripts/runJenkinsJob common-github


### PR DESCRIPTION
- Update ci to call new org wide ci and pass in appropriate input parameters.
- For public testing do nothing for now. There are some issues running testcases on the public runners.
- For private testing call the new script to run the Jenkins job for the common repo.

The make jenkins that used to run on our private runners also had some code to remove RHEL machines from the list of tests to run. This got horribly outdated so until we come up with a better plan public testing is turned off.

We now have a script to call jenkins jobs via the Jenkins API. However, returning success or failure from the job may not currently work. We should work on this if it doesn't.