### PR TITLE
dm vdo test: Ignore use once warning in TestCase.pm

### DIFF
--- a/perl/Permabit/Testcase.pm
+++ b/perl/Permabit/Testcase.pm
@@ -114,6 +114,9 @@ use base qw(
 # This is referenced directly from Permabit::TestRunner.
 our $inTeardown = 0;
 
+# Disable "used only once: possible typo" error in RHEL8
+no warnings 'once';
+
 my $GET_CONSOLE_LOG_CMD
   = '/permabit/build/tools/lastrun/getPSIConsoleLog.py';
 


### PR DESCRIPTION
Add a no warnings 'once' line into TestCase.pm so that we ignore that issue and it will no longer break make jenkins.