### PR TITLE
[RHELMISC-34381] Remove secret inheritance from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,3 @@ jobs:
       private-build-action: make all
       run-private-tests: true
       private-tests-action: make jenkins
-    secrets: inherit


### PR DESCRIPTION
According to github docs, reusable workflows have automatic permissions to github.token and secrets.GITHUB_TOKEN. Remove direct inheritance to harden the workflow code.