### PR TITLE
fix: Correct reusable workflow syntax in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,12 +6,9 @@ on:
       [ closed ]     
 jobs:
   Run-Common-Deployment:
-    if: github.event.pull_request.merged == true  
-    runs-on: [self-hosted, trusted]  
-    steps:
-      - name: Run-Jenkins
-        uses: dm-vdo/vdo-org-actions/.github/workflows/deploy.yaml@main
-        with:
-          deploy-action: |
-            /permabit/ops/scripts/runJenkinsJob common-github
-          deploy-action-failure: echo "deploy failed. see logs"
+    if: github.event.pull_request.merged == true
+    uses: dm-vdo/vdo-org-actions/.github/workflows/deploy.yaml@main
+    with:
+      deploy-action: |
+        /permabit/ops/scripts/runJenkinsJob common-github
+      deploy-action-failure: echo "deploy failed. see logs"


### PR DESCRIPTION
Reusable workflows must be called at the job level with 'uses', not within steps. Move the workflow call from steps to the job level and remove runs-on (defined in the reusable workflow).

This fixes the error: 'reusable workflows should be referenced at the top-level jobs.*.uses key, not within steps'